### PR TITLE
Add arm64 support using buildx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,10 @@ jobs:
     - name: Checkout source
       uses: actions/checkout@v2
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
     - name: Build docker image for ${{ env.VERSION }} ${{ env.VARIANT }}
       run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 # to be the latest.
 LATEST_VERSION=13-3.1
 
+AMD_VERSION1=9.6-2.5
+AMD_VERSION2=10-2.5
+AMD_VERSION3=11-2.5
 # The following flags are set based on VERSION and VARIANT environment variables
 # that may have been specified, and are used by rules to determine which
 # versions/variants are to be processed.  If no VERSION or VARIANT environment
@@ -123,11 +126,15 @@ push: $(foreach version,$(VERSIONS),push-$(version)) $(PUSH_DEP)
 define push-version
 push-$1: test-$1
 ifeq ($(do_default),true)
+ifeq ($(VERSIONS),$(filter $(VERSIONS),$(AMD_VERSION1) $(AMD_VERSION2) $(AMD_VERSION3) ))
 	$(DOCKER) image push $(REPO_NAME)/$(IMAGE_NAME):$(version)
+else
+	$(DOCKER) buildx build --platform linux/arm64,linux/amd64 -t $(REPO_NAME)/$(IMAGE_NAME):$(version) --push $1
+endif
 endif
 ifeq ($(do_alpine),true)
 ifneq ("$(wildcard $1/alpine)","")
-	$(DOCKER) image push $(REPO_NAME)/$(IMAGE_NAME):$(version)-alpine
+	$(DOCKER) buildx build --platform linux/arm64,linux/amd64 -t $(REPO_NAME)/$(IMAGE_NAME):$(version)-alpine --push $1/alpine
 endif
 endif
 endef


### PR DESCRIPTION
Hi

**Package Owner:** Subham Kumar

PR change Details:

**Patch Details:** Following files has been changed :

Makefile: Added support of buildx to build and  push the docker image for arm64 and amd64 platforms.
.github/workflows/main.yml: Updated to build, test and push the images for latest versions to dockerhub.

**PR Description:** 
**Commit message:** Add arm64 support using buildx.

**The following file has been created and modified:**

Added support of buildx in Makefile to build and push the docker image for arm64 and amd64 platforms.
Updated .github/workflows/main.yml to build, test and push the images for latest versions to dockerhub.

**Signed-off-by:** odidev odidev@puresoftware.com

Reviewer: Pruthvi Teja Reddy
Thanks
Subham Kumar